### PR TITLE
Remove conda-forge boost-cpp pin

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,5 +1,3 @@
-boost_cpp:
-- 1.78.0
 c_compiler:
 - gcc
 c_compiler_version:
@@ -16,9 +14,6 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,7 +1,5 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
-boost_cpp:
-- 1.78.0
 c_compiler:
 - gcc
 c_compiler_version:
@@ -20,9 +18,6 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,5 +1,3 @@
-boost_cpp:
-- 1.78.0
 c_compiler:
 - gcc
 c_compiler_version:
@@ -16,9 +14,6 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,7 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.12'
-boost_cpp:
-- 1.78.0
 c_compiler:
 - clang
 c_compiler_version:
@@ -18,9 +16,6 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.12'
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,7 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
-boost_cpp:
-- 1.78.0
 c_compiler:
 - clang
 c_compiler_version:
@@ -16,9 +14,6 @@ cxx_compiler_version:
 - '14'
 macos_machine:
 - arm64-apple-darwin20.0.0
-pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
 target_platform:
 - osx-arm64
 zip_keys:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,6 +42,8 @@ test:
   requires:
     - pkg-config
   commands:
+    - test -f ${PREFIX}/lib/libldastoolsal${SHLIB_EXT}  # [unix]
+    - test -f ${PREFIX}/include/ldastoolsal/ldas_types.h  # [unix]
     - pkg-config --print-errors --exact-version {{ version }} ldastoolsal
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,9 @@ source:
     - no-check-procfs.patch  # [osx and arm64]
 
 build:
-  number: 2
+  error_overdepending: true
+  error_overlinking: true
+  number: 3
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage("ldas-tools-al", max_pin="x.x") }}
@@ -31,7 +33,7 @@ requirements:
     - make  # [unix]
     - pkg-config  # [unix]
   host:
-    - boost-cpp
+    - boost-cpp >=1.67
     - ldas-tools-cmake >={{ ldas_tools_cmake_version }}
   run_constrained:   # [osx and x86_64]
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]


### PR DESCRIPTION
This PR updates the recipe to specify a minimum version of `boost-cpp` - this has the impact of removing the conda-forge boost-cpp pins, which is fine because we only use the header-only boost stuff for this library.

This then removes this library from future boost/boost-cpp migrations, which helps everyone.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
